### PR TITLE
fix capitalization

### DIFF
--- a/calculator/index.css
+++ b/calculator/index.css
@@ -92,7 +92,6 @@ body {
     /*font weight doesn't have to be dynamic*/
     font-weight: 500;
     font-size: var(--font-size);
-    text-transform: uppercase;
 }
 
 #display {

--- a/calculator/index.html
+++ b/calculator/index.html
@@ -61,7 +61,7 @@
             </svg>
         </button>
 
-        <button onClick="emptyAndDisplay()" id="clear">c</button>
+        <button onClick="emptyAndDisplay()" id="clear">C</button>
         <button onClick="pushAndDisplay('.')" id="decimal">.</button>
         <button onClick="calculateAndDisplay()" id="enter">=</button>
 


### PR DESCRIPTION
this PR fixes a bug where all text is capitalized which includes the "e" in scientific notation

my solution is to remove the text-transform from the CSS and then manually capitalize the C used for clearing the display