### PR TITLE
add WebWorker type reference to sw.js

### DIFF
--- a/calculator/sw.js
+++ b/calculator/sw.js
@@ -1,3 +1,5 @@
+/// <reference lib="WebWorker" />
+
 const cacheName = "static-cache-v1";
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
This PR informs typescript based editors (like VS Code) that sw.js is a worker.

This will remove some resolve some type errors related to event handling as well as prevent future issues.